### PR TITLE
add syntax highlighting to markdown code blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,16 @@
         "language": "fish",
         "scopeName": "source.fish",
         "path": "./syntaxes/fish.tmLanguage.json"
+      },
+      {
+        "scopeName": "markdown.fish.codeblock",
+        "path": "./syntaxes/codeblock.json",
+        "injectTo": [
+          "text.html.markdown"
+        ],
+        "embeddedLanguages": {
+          "meta.embedded.block.fish": "fish"
+        }
       }
     ]
   },

--- a/syntaxes/codeblock.json
+++ b/syntaxes/codeblock.json
@@ -1,0 +1,45 @@
+{
+  "fileTypes": [],
+  "injectionSelector": "L:text.html.markdown",
+  "patterns": [
+    {
+      "include": "#fish-code-block"
+    }
+  ],
+  "repository": {
+    "fish-code-block": {
+      "begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(fish)(\\s+[^`~]*)?$)",
+      "name": "markup.fenced_code.block.markdown",
+      "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+      "beginCaptures": {
+        "3": {
+          "name": "punctuation.definition.markdown"
+        },
+        "5": {
+          "name": "fenced_code.block.language"
+        },
+        "6": {
+          "name": "fenced_code.block.language.attributes"
+        }
+      },
+      "endCaptures": {
+        "3": {
+          "name": "punctuation.definition.markdown"
+        }
+      },
+      "patterns": [
+        {
+          "begin": "(^|\\G)(\\s*)(.*)",
+          "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+          "contentName": "meta.embedded.block.fish",
+          "patterns": [
+            {
+              "include": "source.fish"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "scopeName": "markdown.fish.codeblock"
+}


### PR DESCRIPTION
fish codes within markdown code blocks get syntax highlighting now.
Refer to this [example](https://github.com/mjbvz/vscode-fenced-code-block-grammar-injection-example)