### PR TITLE
Recognize files with fish hashbang

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,30 @@
+// A launch configuration that compiles the extension and then opens it inside a new window
+// Use IntelliSense to learn about possible attributes.
+// Hover to view descriptions of existing attributes.
+// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+      "outFiles": ["${workspaceFolder}/out/**/*.js"],
+      "preLaunchTask": "${defaultBuildTask}"
+    },
+    {
+      "name": "Extension Tests",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}",
+        "--extensionTestsPath=${workspaceFolder}/out/test/suite/index"
+      ],
+      "outFiles": ["${workspaceFolder}/out/test/**/*.js"],
+      "preLaunchTask": "${defaultBuildTask}"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "icon": "fish.png",
   "categories": [
     "Programming Languages",
-    "Formatters"
+    "Formatters",
+    "Linters"
   ],
   "keywords": [
     "fish",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
         "extensions": [
           ".fish"
         ],
+        "firstLine": "^#!(/usr)?(/bin/)(env[ \\t]+)?fish$",
         "configuration": "./language-configuration.json"
       }
     ],


### PR DESCRIPTION
I noticed that fish scripts without a `.fish` extension were not recognized by this extension. This PR makes it so that extension-less files with the following hashbangs would be recognized:

- `#!/bin/fish`
- `#!/usr/bin/fish`
- `#!/usr/bin/env fish`

It also ads a `.vscode/launch.json` file because I noticed that was missing when I went to test my changes with `F5`.

Finally, I also added one more bit of metadata to the `package.json` so this extension shows up in the Linters category.