### PR TITLE
Exclude images from extension package

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -8,3 +8,6 @@ vsc-extension-quickstart.md
 **/tslint.json
 **/*.map
 **/*.ts
+*.gif
+*.png
+!fish.png


### PR DESCRIPTION
First of all, thanks for this awesome extension! I noticed some large images are not excluded in the extension package, hence this pull request.

With the images excluded, the package size goes from 2.3MB down to just 59.27KB! It does not break the links as VSCode rewrites assets in README to use GitHub links.