### PR TITLE
Snippets for head/tail/sed, shebangs, option parsing

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -563,6 +563,16 @@
     "description": "take last li[n]es or [b]ytes",
     "body": "tail ${1|-n,-c,--lines,--bytes|} ${2:count}"
   },
+  "take-range": {
+    "prefix": "take-range",
+    "description": "take line range",
+    "body": "sed ${1|-n,--quiet|} '${2:from},${3:to}p'"
+  },
+  "take-stepped-range": {
+    "prefix": "take-stepped-range",
+    "description": "take each n-th line in range",
+    "body": "sed ${1|-n,--quiet|} '${2:from},${3:to}p' | sed $1 '1~${4:step}'"
+  },
   "comment": {
     "prefix": "comment",
     "description": "comment definition",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -571,7 +571,7 @@
   "take-stepped-range": {
     "prefix": "take-stepped-range",
     "description": "take each n-th line in range",
-    "body": "sed ${1|-n,--quiet|} '${2:from},${3:to}p' | sed $1 '1~${4:step}'"
+    "body": "sed ${1|-n,--quiet|} '${2:from},${3:to}p' | sed $1 '1~${4:step}p'"
   },
   "comment": {
     "prefix": "comment",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -543,6 +543,26 @@
       "complete $1 $2 $3 v $4 version $5 'Show version'"
     ]
   },
+  "skip-first": {
+    "prefix": "skip-first",
+    "description": "skip first li[n]es or [b]ytes",
+    "body": "tail ${1|-n,-c,--lines,--bytes|} +${2:count}"
+  },
+  "skip-last": {
+    "prefix": "skip-last",
+    "description": "skip last li[n]es or [b]ytes",
+    "body": "head ${1|-n,-c,--lines,--bytes|} -${2:count}"
+  },
+  "skip-except-first": {
+    "prefix": ["skip-except-first", "take-first"],
+    "description": "take first li[n]es or [b]ytes",
+    "body": "head ${1|-n,-c,--lines,--bytes|} ${2:count}"
+  },
+  "skip-except-last": {
+    "prefix": ["skip-except-last", "take-last"],
+    "description": "take last li[n]es or [b]ytes",
+    "body": "tail ${1|-n,-c,--lines,--bytes|} ${2:count}"
+  },
   "comment": {
     "prefix": "comment",
     "description": "comment definition",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -505,6 +505,22 @@
     "description": "variable existence check",
     "body": "not set ${1|-q,--query|} \"${2:variable}\""
   },
+  "parse": {
+    "prefix": "parse",
+    "description": "option parsing",
+    "body": [
+      "argparse ${1|-n,--name|} ${2:name} 'h/help' 'v/version' ${3:option ...} -- $argv${4|; or, \\|\\||} return",
+      "",
+      "if set ${5|-q,--query|} _flag_help",
+      "\t${6:command ...}",
+      "\treturn 0",
+      "end",
+      "if set $5 _flag_version",
+      "\t${7:command ...}",
+      "\treturn 0",
+      "end"
+    ]
+  },
   "complete": {
     "prefix": "complete",
     "description": "complete option",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -1,4 +1,14 @@
 {
+  "shebang": {
+    "prefix": "shebang",
+    "description": "shebang",
+    "body": "#!/usr/bin/env fish"
+  },
+  "shebang-with-arguments": {
+    "prefix": "shebang-with-arguments",
+    "description": "shebang with arguments",
+    "body": "#!/usr/bin/env ${1|-S,--split-string|} fish ${2|argument ...|}"
+  },
   "and": {
     "prefix": "and",
     "description": "and operator",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -553,13 +553,13 @@
     "description": "skip last li[n]es or [b]ytes",
     "body": "head ${1|-n,-c,--lines,--bytes|} -${2:count}"
   },
-  "skip-except-first": {
-    "prefix": ["skip-except-first", "take-first"],
+  "take-first": {
+    "prefix": "take-first",
     "description": "take first li[n]es or [b]ytes",
     "body": "head ${1|-n,-c,--lines,--bytes|} ${2:count}"
   },
-  "skip-except-last": {
-    "prefix": ["skip-except-last", "take-last"],
+  "take-last": {
+    "prefix": "take-last",
     "description": "take last li[n]es or [b]ytes",
     "body": "tail ${1|-n,-c,--lines,--bytes|} ${2:count}"
   },


### PR DESCRIPTION
- As there are no builtin commands which are easy to use like [`first`, `last`, `skip`, `drop`](https://www.nushell.sh/commands/categories/filters.html) and I am tired of reminding myself where to use `+`/`-` for `--lines` option of head/tail I am adding snippets to solve this headache. Also I've added snippets for quick line filtering via sed.
- Snippets for shebangs.
- Snippet for `argparse`.